### PR TITLE
Add support for non-UTC timezones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/tracing-glog"
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "ansi"], default-features = false }
-chrono = { version = "0.4", features = ["clock", "serde", "std"], default-features = false }
+tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "ansi", "time", "local-time"], default-features = false }
+time = { version = "0.3.9", features = ["formatting"] }
 ansi_term = { version = "0.12" }
 
 [dev-dependencies]

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 use thiserror::Error;
 use tracing::{debug, error, info, span, trace, warn, Level};
-use tracing_glog::{Glog, GlogFields, GlogLocalTime};
+use tracing_glog::{Glog, GlogFields};
 
 /// To run with ANSI colors, run:
 /// ```bash
@@ -25,7 +25,7 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)
-        .event_format(Glog::default().with_timer(GlogLocalTime::new()))
+        .event_format(Glog::default())
         .fmt_fields(GlogFields::default())
         .init();
 

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -25,7 +25,7 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)
-        .event_format(Glog::default())
+        .event_format(Glog::new(chrono::Local))
         .fmt_fields(GlogFields::default())
         .init();
 

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 use thiserror::Error;
 use tracing::{debug, error, info, span, trace, warn, Level};
-use tracing_glog::{Glog, GlogFields};
+use tracing_glog::{Glog, GlogFields, GlogLocalTime};
 
 /// To run with ANSI colors, run:
 /// ```bash
@@ -25,7 +25,7 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)
-        .event_format(Glog::new(chrono::Local))
+        .event_format(Glog::default().with_timer(GlogLocalTime::new()))
         .fmt_fields(GlogFields::default())
         .init();
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -85,18 +85,18 @@ impl fmt::Display for FmtLevel {
 
 /// Formats the current [UTC time] using a [formatter] from the [`time` crate].
 ///
-/// To format the current [local time] instead, use the [`GlogLocalTime`] type.
+/// To format the current [local time] instead, use the [`LocalTime`] type.
 ///
 /// [UTC time]: time::OffsetDateTime::now_utc
 /// [formatter]: time::formatting::Formattable
 /// [`time` crate]: time
 /// [local time]: time::OffsetDateTime::now_local
 #[derive(Clone, Debug)]
-pub struct GlogUtcTime<F = Vec<FormatItem<'static>>> {
+pub struct UtcTime<F = Vec<FormatItem<'static>>> {
     format: F,
 }
 
-impl<F> FormatTime for GlogUtcTime<F>
+impl<F> FormatTime for UtcTime<F>
 where
     F: Formattable,
 {
@@ -115,7 +115,7 @@ where
     }
 }
 
-impl Default for GlogUtcTime {
+impl Default for UtcTime {
     fn default() -> Self {
         let format: Vec<FormatItem> = time::format_description::parse(
             "[month][day] [hour]:[minute]:[second].[subsecond digits:6]",
@@ -127,7 +127,7 @@ impl Default for GlogUtcTime {
 
 /// Formats the current [local time] using a [formatter] from the [`time` crate].
 ///
-/// To format the current [UTC time] instead, use the [`GlogUtcTime`] type.
+/// To format the current [UTC time] instead, use the [`UtcTime`] type.
 ///
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="compile_fail" style="white-space:normal;font:inherit;">
@@ -145,11 +145,11 @@ impl Default for GlogUtcTime {
 /// [`time` crate]: time
 /// [UTC time]: time::OffsetDateTime::now_utc
 #[derive(Clone, Debug)]
-pub struct GlogLocalTime<F = Vec<FormatItem<'static>>> {
+pub struct LocalTime<F = Vec<FormatItem<'static>>> {
     format: F,
 }
 
-impl Default for GlogLocalTime {
+impl Default for LocalTime {
     fn default() -> Self {
         let format: Vec<FormatItem> = time::format_description::parse(
             "[month][day] [hour]:[minute]:[second].[subsecond digits:6]",
@@ -159,7 +159,7 @@ impl Default for GlogLocalTime {
     }
 }
 
-impl<F> FormatTime for GlogLocalTime<F>
+impl<F> FormatTime for LocalTime<F>
 where
     F: Formattable,
 {

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,5 @@
 use ansi_term::{Colour, Style};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone};
 use std::fmt;
 use tracing::{Level, Metadata};
 
@@ -42,18 +42,21 @@ impl fmt::Display for FmtLevel {
     }
 }
 
-pub(crate) struct FormatTimestamp {
-    time: DateTime<Utc>,
+pub(crate) struct FormatTimestamp<Tz: TimeZone> {
+    time: DateTime<Tz>,
     pub ansi: bool,
 }
 
-impl FormatTimestamp {
-    pub(crate) fn format_time(time: DateTime<Utc>, ansi: bool) -> FormatTimestamp {
+impl<Tz: TimeZone> FormatTimestamp<Tz> {
+    pub(crate) fn format_time(time: DateTime<Tz>, ansi: bool) -> FormatTimestamp<Tz> {
         FormatTimestamp { time, ansi }
     }
 }
 
-impl fmt::Display for FormatTimestamp {
+impl<Tz: TimeZone> fmt::Display for FormatTimestamp<Tz>
+where
+    Tz::Offset: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let time = self.time.format("%m%d %H:%M:%S%.6f");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,10 @@
 //! With [`fmt::Subscriber`]:
 //!
 //! ```
-//! use chrono::Local;
 //! use tracing_glog::{Glog, GlogFields};
 //!
 //! tracing_subscriber::fmt()
-//!     .event_format(Glog::new(Local))
+//!     .event_format(Glog::default())
 //!     .fmt_fields(GlogFields::default())
 //!     .init();
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,16 +39,58 @@
 //! tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
 //! ```
 //!
+//! With [`UtcTime`]:
+//!
+//! ```
+//! use tracing_subscriber::prelude::*;
+//! use tracing_subscriber::{fmt, Registcarry};
+//! use tracing_glog::{Glog, GlogFields};
+//!
+//! let fmt = fmt::Layer::default()
+//!     .event_format(Glog::default().with_timer(tracing_glog::UtcTime::default()))
+//!     .fmt_fields(GlogFields::default());
+//!
+//! let subscriber = Registry::default().with(fmt);
+//! tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
+//! ```
+//!
+//! With [`LocalTime`]:
+//!
+//! ```
+//! use tracing_subscriber::prelude::*;
+//! use tracing_subscriber::{fmt, Registcarry};
+//! use tracing_glog::{Glog, GlogFields};
+//!
+//! let fmt = fmt::Layer::default()
+//!     .event_format(Glog::default().with_timer(tracing_glog::LocalTime::default()))
+//!     .fmt_fields(GlogFields::default());
+//!
+//! let subscriber = Registry::default().with(fmt);
+//! tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
+//! ```
+//!
+//! <div class="example-wrap" style="display:inline-block">
+//! <pre class="compile_fail" style="white-space:normal;font:inherit;">
+//!     <strong>Warning</strong>: The <a href = "https://docs.rs/time/0.3/time/"><code>time</code>
+//!     crate</a> must be compiled with <code>--cfg unsound_local_offset</code> in order to use
+//!     `LocalTime`. When this cfg is not enabled, local timestamps cannot be recorded, and
+//!     no events will be emitted.
+//!
+//!    See the <a href="https://docs.rs/time/0.3.9/time/#feature-flags"><code>time</code>
+//!    documentation</a> for more details.
+//! </pre></div>
+//!
 //! [glog]: https://github.com/google/glog
 //! [`tracing-subscriber`]: https://docs.rs/tracing-subscriber
 //! [`fmt::Subscriber`]: tracing_subscriber::fmt::Subscriber
 //! [`fmt::Layer`]: tracing_subscriber::fmt::Layer
+//! [`timer`]: tracing_subscriber::fmt::time
 
 mod format;
 
 use ansi_term::Style;
 use format::FmtLevel;
-pub use format::{GlogLocalTime, GlogUtcTime};
+pub use format::{LocalTime, UtcTime};
 use std::fmt;
 use tracing::{
     field::{Field, Visit},
@@ -64,11 +106,20 @@ use tracing_subscriber::{
 
 use crate::format::{FormatProcessData, FormatSpanFields};
 
-pub struct Glog<T = GlogLocalTime> {
+/// A [glog]-inspired span and event formatter.
+///
+/// [glog]: https://github.com/google/glog
+pub struct Glog<T = UtcTime> {
     timer: T,
 }
 
 impl<T> Glog<T> {
+    /// Use the given [timer] for span and event time stamps.
+    ///
+    /// `tracing-glog` provides two timers: [`LocalTime`] and [`UtcTime`].
+    /// [`UtcTime`] is the default timer.
+    ///
+    /// [timer]: tracing_subscriber::fmt::time::FormatTime
     pub fn with_timer<T2>(&mut self, timer: T2) -> Glog<T2>
     where
         T2: FormatTime,
@@ -77,10 +128,10 @@ impl<T> Glog<T> {
     }
 }
 
-impl Default for Glog<GlogLocalTime> {
+impl Default for Glog<UtcTime> {
     fn default() -> Self {
         Glog {
-            timer: GlogLocalTime::default(),
+            timer: UtcTime::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 mod format;
 
 use ansi_term::Style;
-use chrono::{Utc, TimeZone};
+use chrono::{TimeZone, Utc};
 use format::FmtLevel;
 use std::fmt;
 use tracing::{
@@ -69,9 +69,7 @@ pub struct Glog<Tz: TimeZone> {
 
 impl<Tz: TimeZone> Glog<Tz> {
     pub fn new(timezone: Tz) -> Self {
-        Self {
-            timezone,
-        }
+        Self { timezone }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ where
         let thread = std::thread::current();
         let thread_name = thread.name();
 
-        let data = FormatProcessData::new(
+        let data = FormatProcessData::format_process_data(
             pid,
             thread_name,
             event.metadata(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ```
 //! use tracing_subscriber::prelude::*;
-//! use tracing_subscriber::{fmt, Registcarry};
+//! use tracing_subscriber::{fmt, Registry};
 //! use tracing_glog::{Glog, GlogFields};
 //!
 //! let fmt = fmt::Layer::default()
@@ -58,7 +58,7 @@
 //!
 //! ```
 //! use tracing_subscriber::prelude::*;
-//! use tracing_subscriber::{fmt, Registcarry};
+//! use tracing_subscriber::{fmt, Registry};
 //! use tracing_glog::{Glog, GlogFields};
 //!
 //! let fmt = fmt::Layer::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,16 +58,14 @@ use tracing::{
 use tracing_subscriber::{
     field::{MakeVisitor, VisitFmt, VisitOutput},
     fmt::{
-        format::Writer,
-        time::{FormatTime, SystemTime},
-        FmtContext, FormatEvent, FormatFields, FormattedFields,
+        format::Writer, time::FormatTime, FmtContext, FormatEvent, FormatFields, FormattedFields,
     },
     registry::LookupSpan,
 };
 
 use crate::format::{FormatProcessData, FormatSpanFields};
 
-pub struct Glog<T = GlogUtcTime> {
+pub struct Glog<T = GlogLocalTime> {
     timer: T,
 }
 
@@ -80,9 +78,11 @@ impl<T> Glog<T> {
     }
 }
 
-impl Default for Glog<SystemTime> {
+impl Default for Glog<GlogLocalTime> {
     fn default() -> Self {
-        Glog { timer: SystemTime }
+        Glog {
+            timer: GlogLocalTime::default(),
+        }
     }
 }
 


### PR DESCRIPTION
This diff makes it possible to provide custom timezones to the glog
formatter, such as chrono::Local.

It keeps Glog::default() the same, so it should be backwards compatible.