### PR TITLE
feat: add a toggle for span context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ ansi_term = { version = "0.12" }
 thiserror = "1"
 structopt = "0.3"
 tracing = { version = "0.1" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -16,8 +16,12 @@ use tracing_glog::{Glog, GlogFields};
 #[derive(Debug, structopt::StructOpt)]
 struct Args {
     /// Whether to run this example with or without ANSI colors.
-    #[structopt(short, long)]
+    #[structopt(long)]
     with_ansi: bool,
+
+    /// Whether tracing-glog should include the span context.
+    #[structopt(long)]
+    with_span_context: bool,
 }
 
 fn main() {
@@ -25,7 +29,7 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)
-        .event_format(Glog::default())
+        .event_format(Glog::default().with_span_context(args.with_span_context))
         .fmt_fields(GlogFields::default())
         .init();
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -198,9 +198,7 @@ pub(crate) struct FormatProcessData<'a> {
 }
 
 impl<'a> FormatProcessData<'a> {
-    // allowing this i disagree with clippy.
-    #[allow(clippy::self_named_constructors)]
-    pub(crate) fn format_process_data(
+    pub(crate) fn new(
         pid: u32,
         thread_name: Option<&'a str>,
         metadata: &'static Metadata<'static>,


### PR DESCRIPTION
This branch adds an off-by-default toggle that disables the span context, as some new Rust/tracing users have found the span context to be overwhelming.