### PR TITLE
feature: Add Toggle for Threads Names and Targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ ansi_term = { version = "0.12" }
 
 [dev-dependencies]
 thiserror = "1"
+anyhow = "1"
 structopt = "0.3"
 tracing = { version = "0.1" }
+tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -15,7 +15,8 @@ async fn parent_task(subtasks: usize) -> Result<(), Error> {
     }
 
     // the returnable error would be if one of the subtasks panicked.
-    while let Ok(task) = set.join_one().await.unwrap() {
+    while let Some(task) = set.join_one().await {
+        let task = task?;
         debug!(%task, "task completed");
     }
 
@@ -30,8 +31,7 @@ async fn subtask(number: usize) -> usize {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        // .with_max_level(tracing::Level::INFO)
-        .with_ansi(false)
+        .with_ansi(true)
         .event_format(
             Glog::default()
                 .with_target(false)

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
-use tracing_glog::{Glog, GlogFields, GlogUtcTime};
+use tracing_glog::{Glog, GlogFields, UtcTime};
 
 #[instrument]
 async fn parent_task(subtasks: usize) -> Result<(), Error> {
@@ -15,7 +15,7 @@ async fn parent_task(subtasks: usize) -> Result<(), Error> {
     }
 
     // the returnable error would be if one of the subtasks panicked.
-    while let Some(task) = set.join_one().await? {
+    while let Ok(task) = set.join_one().await.unwrap() {
         debug!(%task, "task completed");
     }
 
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(GlogUtcTime::default()),
+                .with_timer(UtcTime::default()),
         )
         .fmt_fields(GlogFields::default())
         .init();

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,0 +1,45 @@
+use anyhow::Error;
+use tokio::task::JoinSet;
+use tracing::{debug, info, instrument, span, Instrument as _, Level};
+use tracing_glog::{Glog, GlogFields, GlogUtcTime};
+
+#[instrument]
+async fn parent_task(subtasks: usize) -> Result<(), Error> {
+    info!("spawning subtasks...");
+    let mut set = JoinSet::new();
+
+    for number in 1..=subtasks {
+        let span = span!(Level::INFO, "subtask", %number);
+        debug!(message = "creating subtask;", number);
+        set.spawn(subtask(number).instrument(span));
+    }
+
+    // the returnable error would be if one of the subtasks panicked.
+    while let Some(task) = set.join_one().await? {
+        debug!(%task, "task completed");
+    }
+
+    Ok(())
+}
+
+async fn subtask(number: usize) -> usize {
+    info!(%number, "polling subtask");
+    number
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        // .with_max_level(tracing::Level::INFO)
+        .with_ansi(false)
+        .event_format(
+            Glog::default()
+                .with_target(false)
+                .with_thread_names(false)
+                .with_timer(GlogUtcTime::default()),
+        )
+        .fmt_fields(GlogFields::default())
+        .init();
+    parent_task(10).await?;
+    Ok(())
+}

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 use thiserror::Error;
 use tracing::{debug, error, info, span, trace, warn, Level};
-use tracing_glog::{Glog, GlogFields};
+use tracing_glog::{Glog, GlogFields, LocalTime};
 
 /// To run with ANSI colors, run:
 /// ```bash

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -29,12 +29,7 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)
-        .event_format(
-            Glog::default()
-                .with_target(true)
-                .with_thread_names(true)
-                .with_span_context(args.with_span_context),
-        )
+        .event_format(Glog::default().with_span_context(args.with_span_context))
         .fmt_fields(GlogFields::default())
         .init();
 

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -29,7 +29,12 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)
-        .event_format(Glog::default().with_span_context(args.with_span_context))
+        .event_format(
+            Glog::default()
+                .with_target(true)
+                .with_thread_names(true)
+                .with_span_context(args.with_span_context),
+        )
         .fmt_fields(GlogFields::default())
         .init();
 

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 use thiserror::Error;
 use tracing::{debug, error, info, span, trace, warn, Level};
-use tracing_glog::{Glog, GlogFields, LocalTime};
+use tracing_glog::{Glog, GlogFields};
 
 /// To run with ANSI colors, run:
 /// ```bash

--- a/src/format.rs
+++ b/src/format.rs
@@ -107,7 +107,7 @@ where
             let style = Style::new().dimmed();
             write!(writer, "{}", style.prefix())?;
             format_datetime(writer, now, &self.format)?;
-            write!(writer, "{}", style.suffix())?;
+            write!(writer, "{} ", style.suffix())?;
             return Ok(());
         }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -107,7 +107,7 @@ where
             let style = Style::new().dimmed();
             write!(writer, "{}", style.prefix())?;
             format_datetime(writer, now, &self.format)?;
-            write!(writer, "{} ", style.suffix())?;
+            write!(writer, "{}", style.suffix())?;
             return Ok(());
         }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -214,10 +214,11 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
         if self.ansi {
             let style = Style::new().bold();
             // start by bolding all the expected data
-            write!(f, " {}", style.prefix())?;
-            if self.with_thread_names || thread_name.is_some() {
-                let thread_name = thread_name.unwrap();
-                write!(f, "{}", thread_name)?;
+            write!(f, "{}", style.prefix())?;
+            if let Some(name) = thread_name {
+                if self.with_thread_names {
+                    write!(f, " {}", name)?
+                }
             }
 
             if self.with_target {
@@ -230,9 +231,10 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
             write!(f, "{}", style.suffix())?;
             Ok(())
         } else {
-            if self.with_thread_names && thread_name.is_some() {
-                let thread_name = thread_name.unwrap();
-                write!(f, " {}", thread_name)?;
+            if let Some(name) = thread_name {
+                if self.with_thread_names {
+                    write!(f, " {}", name)?
+                }
             }
 
             if self.with_target {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,26 @@ impl<T> Glog<T> {
         }
     }
 
+    /// Sets whether or not the span context is included. Defaults to true.
+    ///
+    /// By default, formatters building atop of [`mod@tracing_subscriber::fmt`]
+    /// will include the span context as [`fmt::Layer`] and
+    /// [`fmt::Subscriber`] assume that span context is
+    /// is valuable and the _raison d’être_ for using `tracing` and, as such, do not provide a
+    /// toggle. However, users migrating from logging systems such
+    /// as [glog](https://github.com/google/glog) or folly's [`xlog`](https://github.com/facebook/folly/blob/main/folly/logging/xlog.h)
+    /// might find the span context to be overwhelming. Therefore, this formatter-level toggle
+    /// is availible in order to provide a smoother onboarding experience to [`tracing`].
+    ///
+    /// **Notice:** This is a relatively coarse toggle. In most circumstances, usage of
+    /// `tracing-subscriber`'s [`filter_fn`] is preferred to disable spans on a more
+    /// fine-grained basis.
+    ///
+    /// [`fmt::Layer`]: tracing_subscriber::fmt::Layer
+    /// [`fmt::Subscriber`]: tracing_subscriber::fmt::Subscriber
+    /// [per-layer filtering]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/index.html#per-layer-filtering
+    /// [`filter_fn`]: fn@tracing_subscriber::filter::filter_fn
+    /// [`tracing`]: mod@tracing
     pub fn with_span_context(self, with_span_context: bool) -> Glog<T> {
         Glog {
             with_span_context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,8 @@ use crate::format::{FormatProcessData, FormatSpanFields};
 pub struct Glog<T = UtcTime> {
     timer: T,
     with_span_context: bool,
+    with_thread_names: bool,
+    with_target: bool,
 }
 
 impl<T> Glog<T> {
@@ -132,32 +134,28 @@ impl<T> Glog<T> {
     {
         Glog {
             timer,
+            with_thread_names: self.with_thread_names,
+            with_target: self.with_target,
             with_span_context: self.with_span_context,
         }
     }
 
-    /// Sets whether or not the span context is included. Defaults to true.
-    ///
-    /// By default, formatters building atop of [`mod@tracing_subscriber::fmt`]
-    /// will include the span context as [`fmt::Layer`] and
-    /// [`fmt::Subscriber`] assume that span context is
-    /// is valuable and the _raison d’être_ for using `tracing` and, as such, do not provide a
-    /// toggle. However, users migrating from logging systems such
-    /// as [glog](https://github.com/google/glog) or folly's [`xlog`](https://github.com/facebook/folly/blob/main/folly/logging/xlog.h)
-    /// might find the span context to be overwhelming. Therefore, this formatter-level toggle
-    /// is availible in order to provide a smoother onboarding experience to [`tracing`].
-    ///
-    /// **Notice:** This is a relatively coarse toggle. In most circumstances, usage of
-    /// `tracing-subscriber`'s [`filter_fn`] is preferred to disable spans on a more
-    /// fine-grained basis.
-    ///
-    /// [`fmt::Layer`]: tracing_subscriber::fmt::Layer
-    /// [`fmt::Subscriber`]: tracing_subscriber::fmt::Subscriber
-    /// [per-layer filtering]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/index.html#per-layer-filtering
-    /// [`filter_fn`]: fn@tracing_subscriber::filter::filter_fn
-    /// [`tracing`]: mod@tracing
-    pub fn with_span_context(self, with_span_context: bool) -> Self {
-        Self {
+    pub fn with_thread_names(self, with_thread_names: bool) -> Glog<T> {
+        Glog {
+            with_thread_names,
+            ..self
+        }
+    }
+
+    pub fn with_target(self, with_target: bool) -> Glog<T> {
+        Glog {
+            with_target,
+            ..self
+        }
+    }
+
+    pub fn with_span_context(self, with_span_context: bool) -> Glog<T> {
+        Glog {
             with_span_context,
             ..self
         }
@@ -168,6 +166,8 @@ impl Default for Glog<UtcTime> {
     fn default() -> Self {
         Glog {
             timer: UtcTime::default(),
+            with_thread_names: false,
+            with_target: false,
             with_span_context: true,
         }
     }
@@ -199,13 +199,15 @@ where
         let thread = std::thread::current();
         let thread_name = thread.name();
 
-        let data = FormatProcessData::new(
+        let data = FormatProcessData {
             pid,
             thread_name,
-            event.metadata(),
-            writer.has_ansi_escapes(),
-        );
-        write!(writer, "{}] ", data)?;
+            with_thread_names: self.with_thread_names,
+            metadata: event.metadata(),
+            with_target: self.with_target,
+            ansi: writer.has_ansi_escapes(),
+        };
+        write!(writer, "{}]", data)?;
 
         if self.with_span_context {
             // now, we're printing the span context into brackets of `[]`, which glog parsers ignore.


### PR DESCRIPTION
(builds on #1. Will rebase once that is merged.)

This PR adds:
- a builder toggle on `Glog` to enable/disable thread names and targets, as glog does not have this information enabled by default.
- an example of tracing-glog used with Tokio; pilfered from https://github.com/tokio-rs/tracing/blob/master/examples/examples/tokio-spawny-thing.rs.

Still to do: docs.

