### PR TITLE
chore: switch to `nu-ansi-term` from `ansi-term`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1"
 anyhow = "1"
 structopt = "0.3"
 tracing = { version = "0.1" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/tracing-glog"
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "ansi", "time", "local-time"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
-ansi_term = { version = "0.12" }
+nu-ansi-term = { version = "0.46" }
 
 [dev-dependencies]
 thiserror = "1"

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -15,7 +15,7 @@ async fn parent_task(subtasks: usize) -> Result<(), Error> {
     }
 
     // the returnable error would be if one of the subtasks panicked.
-    while let Some(task) = set.join_one().await {
+    while let Some(task) = set.join_next().await {
         let task = task?;
         debug!(%task, "task completed");
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,4 @@
-use ansi_term::{Colour, Style};
+use nu_ansi_term::{Color, Style};
 use std::{fmt, io};
 use time::{format_description::FormatItem, formatting::Formattable, OffsetDateTime};
 use tracing::{Level, Metadata};
@@ -16,7 +16,7 @@ pub(crate) struct WriteAdaptor<'a> {
 }
 
 impl<'a> WriteAdaptor<'a> {
-    pub(in crate) fn new(fmt_write: &'a mut dyn fmt::Write) -> Self {
+    pub(crate) fn new(fmt_write: &'a mut dyn fmt::Write) -> Self {
         Self { fmt_write }
     }
 }
@@ -65,11 +65,11 @@ impl fmt::Display for FmtLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.ansi {
             match self.level {
-                Level::TRACE => write!(f, "{}", Colour::Purple.paint(Self::TRACE_STR)),
-                Level::DEBUG => write!(f, "{}", Colour::Blue.paint(Self::DEBUG_STR)),
-                Level::INFO => write!(f, "{}", Colour::Green.paint(Self::INFO_STR)),
-                Level::WARN => write!(f, "{}", Colour::Yellow.paint(Self::WARN_STR)),
-                Level::ERROR => write!(f, "{}", Colour::Red.paint(Self::ERROR_STR)),
+                Level::TRACE => write!(f, "{}", Color::Purple.paint(Self::TRACE_STR)),
+                Level::DEBUG => write!(f, "{}", Color::Blue.paint(Self::DEBUG_STR)),
+                Level::INFO => write!(f, "{}", Color::Green.paint(Self::INFO_STR)),
+                Level::WARN => write!(f, "{}", Color::Yellow.paint(Self::WARN_STR)),
+                Level::ERROR => write!(f, "{}", Color::Red.paint(Self::ERROR_STR)),
             }
         } else {
             match self.level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,9 @@
 #[deny(rustdoc::broken_intra_doc_links)]
 mod format;
 
-use ansi_term::Style;
 use format::FmtLevel;
 pub use format::{LocalTime, UtcTime};
+use nu_ansi_term::Style;
 use std::fmt;
 use tracing::{
     field::{Field, Visit},


### PR DESCRIPTION
This follows `tracing-subscriber`'s recent move to `nu-ansi-term` and reduces dependency duplication in users of `tracing-glog`.