### PR TITLE
Put space between `]` and rest of log line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ where
             with_target: self.with_target,
             ansi: writer.has_ansi_escapes(),
         };
-        write!(writer, "{}]", data)?;
+        write!(writer, "{}] ", data)?;
 
         if self.with_span_context {
             // now, we're printing the span context into brackets of `[]`, which glog parsers ignore.


### PR DESCRIPTION
Previously:
```
I1013 00:10:23.280450 2557418 cip/hallmark/service/main.rs:207]started serve_background
```
Now:
```
I1013 00:10:23.280450 2557418 cip/hallmark/service/main.rs:207] started serve_background
```

This matches glog's formatting.