### PR TITLE
chore: prepare 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-glog"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "a glog-inspired formatter for tracing-subscriber"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- bug: add space between `]` and rest of log line (#7)
- chore: switch to `nu-ansi-term` from `ansi-term` (#6)