### PR TITLE
Make ansi colour rendering optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/tracing-glog"
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "ansi", "time", "local-time"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
-nu-ansi-term = { version = "0.46" }
+nu-ansi-term = { version = "0.46", optional = true }
 
 [dev-dependencies]
 thiserror = "1"
@@ -21,6 +21,10 @@ anyhow = "1"
 structopt = "0.3"
 tracing = { version = "0.1" }
 tokio = { version = "1.21", features = ["full"] }
+
+[features]
+default = ["ansi"]
+ansi = ["nu-ansi-term"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tracing-glog"
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "ansi", "time", "local-time"], default-features = false }
+tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "time", "local-time"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
 nu-ansi-term = { version = "0.46", optional = true }
 
@@ -24,7 +24,7 @@ tokio = { version = "1.21", features = ["full"] }
 
 [features]
 default = ["ansi"]
-ansi = ["nu-ansi-term"]
+ansi = ["nu-ansi-term", "tracing-subscriber/ansi"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/format.rs
+++ b/src/format.rs
@@ -58,14 +58,14 @@ impl FmtLevel {
     const WARN_STR: &'static str = "W";
     const ERROR_STR: &'static str = "E";
 
-    pub(crate) fn format_level(level: Level, _ansi: bool) -> FmtLevel {
-        #[cfg(feature = "ansi")]
-        {
-            FmtLevel { level, ansi: _ansi }
-        }
+    pub(crate) fn format_level(level: Level, ansi: bool) -> FmtLevel {
         #[cfg(not(feature = "ansi"))]
-        {
-            FmtLevel { level }
+        let _ = ansi;
+        #[cfg(feature = "ansi")]
+        FmtLevel {
+            level,
+            #[cfg(feature = "ansi")]
+            ansi,
         }
     }
 }
@@ -272,13 +272,15 @@ impl<'a> FormatSpanFields<'a> {
     pub(crate) fn format_fields(
         span_name: &'static str,
         fields: Option<&'a str>,
-        _ansi: bool,
+        ansi: bool,
     ) -> Self {
+        #[cfg(not(feature = "ansi"))]
+        let _ = ansi;
         Self {
             span_name,
             fields,
             #[cfg(feature = "ansi")]
-            ansi: _ansi,
+            ansi,
         }
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,5 @@
-use nu_ansi_term::{Color, Style};
+#[cfg(feature = "ansi")]
+use crate::nu_ansi_term::{Color, Style};
 use std::{fmt, io};
 use time::{format_description::FormatItem, formatting::Formattable, OffsetDateTime};
 use tracing::{Level, Metadata};
@@ -46,6 +47,7 @@ impl<'a> fmt::Debug for WriteAdaptor<'a> {
 
 pub(crate) struct FmtLevel {
     pub level: Level,
+    #[cfg(feature = "ansi")]
     pub ansi: bool,
 }
 
@@ -56,29 +58,36 @@ impl FmtLevel {
     const WARN_STR: &'static str = "W";
     const ERROR_STR: &'static str = "E";
 
-    pub(crate) fn format_level(level: Level, ansi: bool) -> FmtLevel {
-        FmtLevel { level, ansi }
+    pub(crate) fn format_level(level: Level, _ansi: bool) -> FmtLevel {
+        #[cfg(feature = "ansi")]
+        {
+            FmtLevel { level, ansi: _ansi }
+        }
+        #[cfg(not(feature = "ansi"))]
+        {
+            FmtLevel { level }
+        }
     }
 }
 
 impl fmt::Display for FmtLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "ansi")]
         if self.ansi {
-            match self.level {
+            return match self.level {
                 Level::TRACE => write!(f, "{}", Color::Purple.paint(Self::TRACE_STR)),
                 Level::DEBUG => write!(f, "{}", Color::Blue.paint(Self::DEBUG_STR)),
                 Level::INFO => write!(f, "{}", Color::Green.paint(Self::INFO_STR)),
                 Level::WARN => write!(f, "{}", Color::Yellow.paint(Self::WARN_STR)),
                 Level::ERROR => write!(f, "{}", Color::Red.paint(Self::ERROR_STR)),
-            }
-        } else {
-            match self.level {
-                Level::TRACE => f.pad(Self::TRACE_STR),
-                Level::DEBUG => f.pad(Self::DEBUG_STR),
-                Level::INFO => f.pad(Self::INFO_STR),
-                Level::WARN => f.pad(Self::WARN_STR),
-                Level::ERROR => f.pad(Self::ERROR_STR),
-            }
+            };
+        }
+        match self.level {
+            Level::TRACE => f.pad(Self::TRACE_STR),
+            Level::DEBUG => f.pad(Self::DEBUG_STR),
+            Level::INFO => f.pad(Self::INFO_STR),
+            Level::WARN => f.pad(Self::WARN_STR),
+            Level::ERROR => f.pad(Self::ERROR_STR),
         }
     }
 }
@@ -103,6 +112,7 @@ where
     fn format_time(&self, writer: &mut Writer<'_>) -> fmt::Result {
         let now = OffsetDateTime::now_utc();
 
+        #[cfg(feature = "ansi")]
         if writer.has_ansi_escapes() {
             let style = Style::new().dimmed();
             write!(writer, "{}", style.prefix())?;
@@ -166,6 +176,7 @@ where
     fn format_time(&self, writer: &mut Writer<'_>) -> fmt::Result {
         let now = OffsetDateTime::now_local().map_err(|_| fmt::Error)?;
 
+        #[cfg(feature = "ansi")]
         if writer.has_ansi_escapes() {
             let style = Style::new().dimmed();
             write!(writer, "{}", style.prefix())?;
@@ -196,6 +207,7 @@ pub(crate) struct FormatProcessData<'a> {
     pub(crate) with_thread_names: bool,
     pub(crate) metadata: &'static Metadata<'static>,
     pub(crate) with_target: bool,
+    #[cfg(feature = "ansi")]
     pub(crate) ansi: bool,
 }
 
@@ -211,6 +223,7 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
         // write the always unstyled PID
         write!(f, " {pid:>5}", pid = self.pid)?;
 
+        #[cfg(feature = "ansi")]
         if self.ansi {
             let style = Style::new().bold();
             // start by bolding all the expected data
@@ -229,21 +242,21 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
 
             // end bolding
             write!(f, "{}", style.suffix())?;
-            Ok(())
-        } else {
-            if let Some(name) = thread_name {
-                if self.with_thread_names {
-                    write!(f, " {}", name)?
-                }
-            }
 
-            if self.with_target {
-                write!(f, " [{}]", target)?;
-            }
-
-            write!(f, " {file}:{line}", file = file, line = line)?;
-            Ok(())
+            return Ok(());
         }
+        if let Some(name) = thread_name {
+            if self.with_thread_names {
+                write!(f, " {}", name)?
+            }
+        }
+
+        if self.with_target {
+            write!(f, " [{}]", target)?;
+        }
+
+        write!(f, " {file}:{line}", file = file, line = line)?;
+        Ok(())
     }
 }
 
@@ -251,6 +264,7 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
 pub(crate) struct FormatSpanFields<'a> {
     span_name: &'static str,
     fields: Option<&'a str>,
+    #[cfg(feature = "ansi")]
     pub ansi: bool,
 }
 
@@ -258,18 +272,20 @@ impl<'a> FormatSpanFields<'a> {
     pub(crate) fn format_fields(
         span_name: &'static str,
         fields: Option<&'a str>,
-        ansi: bool,
+        _ansi: bool,
     ) -> Self {
         Self {
             span_name,
             fields,
-            ansi,
+            #[cfg(feature = "ansi")]
+            ansi: _ansi,
         }
     }
 }
 
 impl<'a> fmt::Display for FormatSpanFields<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "ansi")]
         if self.ansi {
             let bold = Style::new().bold();
             write!(f, "{}", bold.paint(self.span_name))?;
@@ -278,14 +294,13 @@ impl<'a> fmt::Display for FormatSpanFields<'a> {
             if let Some(fields) = self.fields {
                 write!(f, "{{{}}}", italic.paint(fields))?;
             };
-            Ok(())
-        } else {
-            write!(f, "{}", self.span_name)?;
-            if let Some(fields) = self.fields {
-                write!(f, "{{{}}}", fields)?;
-            };
-
-            Ok(())
+            return Ok(());
         }
+        write!(f, "{}", self.span_name)?;
+        if let Some(fields) = self.fields {
+            write!(f, "{{{}}}", fields)?;
+        };
+
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,38 @@
 #[deny(rustdoc::broken_intra_doc_links)]
 mod format;
 
+#[cfg(feature = "ansi")]
+mod nu_ansi_term {
+    pub use ::nu_ansi_term::*;
+}
+#[cfg(not(feature = "ansi"))]
+mod nu_ansi_term {
+    // Minimal API shim for nu_ansi_term to avoid a pile of #[cfg(feature = "ansi")] directives.
+    #[derive(Copy, Clone)]
+    pub struct Style;
+
+    impl Style {
+        pub fn new() -> Self {
+            Style
+        }
+        pub fn bold(&self) -> Self {
+            Style
+        }
+        pub fn prefix(&self) -> &'static str {
+            ""
+        }
+        pub fn infix(&self, _: Style) -> &'static str {
+            ""
+        }
+        pub fn suffix(&self) -> &'static str {
+            ""
+        }
+    }
+}
+
+use crate::nu_ansi_term::Style;
 use format::FmtLevel;
 pub use format::{LocalTime, UtcTime};
-use nu_ansi_term::Style;
 use std::fmt;
 use tracing::{
     field::{Field, Visit},
@@ -225,6 +254,7 @@ where
             with_thread_names: self.with_thread_names,
             metadata: event.metadata(),
             with_target: self.with_target,
+            #[cfg(feature = "ansi")]
             ansi: writer.has_ansi_escapes(),
         };
         write!(writer, "{}] ", data)?;


### PR DESCRIPTION
Add an `ansi` feature (enabled by default) which enables styled output; without this the glog output is plain. Removing it also removes the dependency on nu-ansi-term.

Since glog is primarily used to interoperate with other tools which can consume glog-formatted files, styled output is generally undesireable since those other tools could be confused by embedded ansi sequences. In general glog is not a great format for direct user presentation - there are lots of other options.