### PR TITLE
chore: prepare 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-glog"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "a glog-inspired formatter for tracing-subscriber"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "time", "local-time"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
 nu-ansi-term = { version = "0.46", optional = true }
+tracing-log = { version = "0.1", optional = true }
 
 [dev-dependencies]
 thiserror = "1"
@@ -25,6 +26,7 @@ tokio = { version = "1.21", features = ["full"] }
 [features]
 default = ["ansi"]
 ansi = ["nu-ansi-term", "tracing-subscriber/ansi"]
+tracing-log = ["dep:tracing-log"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/format.rs
+++ b/src/format.rs
@@ -61,7 +61,6 @@ impl FmtLevel {
     pub(crate) fn format_level(level: Level, ansi: bool) -> FmtLevel {
         #[cfg(not(feature = "ansi"))]
         let _ = ansi;
-        #[cfg(feature = "ansi")]
         FmtLevel {
             level,
             #[cfg(feature = "ansi")]

--- a/src/format.rs
+++ b/src/format.rs
@@ -204,7 +204,7 @@ pub(crate) struct FormatProcessData<'a> {
     pub(crate) pid: u32,
     pub(crate) thread_name: Option<&'a str>,
     pub(crate) with_thread_names: bool,
-    pub(crate) metadata: &'static Metadata<'static>,
+    pub(crate) metadata: &'a Metadata<'a>,
     pub(crate) with_target: bool,
     #[cfg(feature = "ansi")]
     pub(crate) ansi: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,8 @@ use tracing::{
     field::{Field, Visit},
     Subscriber,
 };
+#[cfg(feature = "tracing-log")]
+use tracing_log::NormalizeEvent;
 use tracing_subscriber::{
     field::{MakeVisitor, VisitFmt, VisitOutput},
     fmt::{
@@ -248,11 +250,18 @@ where
         let thread = std::thread::current();
         let thread_name = thread.name();
 
+        #[cfg(feature = "tracing-log")]
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let metadata = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        #[cfg(not(feature = "tracing-log"))]
+        let metadata = event.metadata();
+
         let data = FormatProcessData {
             pid,
             thread_name,
             with_thread_names: self.with_thread_names,
-            metadata: event.metadata(),
+            metadata,
             with_target: self.with_target,
             #[cfg(feature = "ansi")]
             ansi: writer.has_ansi_escapes(),


### PR DESCRIPTION
- feature: make ansi colour rendering optional (#9)
- fix: fix !ansi compilation (#11)
- feat: normalize event metadata if coming from tracing-log (#12)