### PR TITLE
Normalize event metadata if coming from tracing-log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "time", "local-time"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
 nu-ansi-term = { version = "0.46", optional = true }
+tracing-log = { version = "0.1", optional = true }
 
 [dev-dependencies]
 thiserror = "1"
@@ -25,6 +26,7 @@ tokio = { version = "1.21", features = ["full"] }
 [features]
 default = ["ansi"]
 ansi = ["nu-ansi-term", "tracing-subscriber/ansi"]
+tracing-log = ["dep:tracing-log"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/format.rs
+++ b/src/format.rs
@@ -61,7 +61,6 @@ impl FmtLevel {
     pub(crate) fn format_level(level: Level, ansi: bool) -> FmtLevel {
         #[cfg(not(feature = "ansi"))]
         let _ = ansi;
-        #[cfg(feature = "ansi")]
         FmtLevel {
             level,
             #[cfg(feature = "ansi")]

--- a/src/format.rs
+++ b/src/format.rs
@@ -205,7 +205,7 @@ pub(crate) struct FormatProcessData<'a> {
     pub(crate) pid: u32,
     pub(crate) thread_name: Option<&'a str>,
     pub(crate) with_thread_names: bool,
-    pub(crate) metadata: &'static Metadata<'static>,
+    pub(crate) metadata: &'a Metadata<'a>,
     pub(crate) with_target: bool,
     #[cfg(feature = "ansi")]
     pub(crate) ansi: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,8 @@ use tracing::{
     field::{Field, Visit},
     Subscriber,
 };
+#[cfg(feature = "tracing-log")]
+use tracing_log::NormalizeEvent;
 use tracing_subscriber::{
     field::{MakeVisitor, VisitFmt, VisitOutput},
     fmt::{
@@ -248,11 +250,19 @@ where
         let thread = std::thread::current();
         let thread_name = thread.name();
 
+        #[allow(unused_assignments, unused_mut)]
+        let mut metadata = None;
+
+        #[cfg(feature = "tracing-log")]
+        {
+            metadata = event.normalized_metadata();
+        }
+
         let data = FormatProcessData {
             pid,
             thread_name,
             with_thread_names: self.with_thread_names,
-            metadata: event.metadata(),
+            metadata: metadata.as_ref().unwrap_or_else(|| event.metadata()),
             with_target: self.with_target,
             #[cfg(feature = "ansi")]
             ansi: writer.has_ansi_escapes(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,19 +250,18 @@ where
         let thread = std::thread::current();
         let thread_name = thread.name();
 
-        #[allow(unused_assignments, unused_mut)]
-        let mut metadata = None;
-
         #[cfg(feature = "tracing-log")]
-        {
-            metadata = event.normalized_metadata();
-        }
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let metadata = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        #[cfg(not(feature = "tracing-log"))]
+        let metadata = event.metadata();
 
         let data = FormatProcessData {
             pid,
             thread_name,
             with_thread_names: self.with_thread_names,
-            metadata: metadata.as_ref().unwrap_or_else(|| event.metadata()),
+            metadata,
             with_target: self.with_target,
             #[cfg(feature = "ansi")]
             ansi: writer.has_ansi_escapes(),


### PR DESCRIPTION
Add `tracing-log` feature which will use tracing-log's `NormalizeEvent` trait to re-insert file and line info that's missing from the original callsite metadata.