### PR TITLE
Add option with_short_file_names

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -223,8 +223,8 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
                     let path = Path::new(f);
                     path.file_name()
                         .map(OsStr::to_str)
-                        .unwrap_or_default()
-                        .unwrap_or_default()
+                        .unwrap_or(Some(f))
+                        .unwrap_or(f)
                 } else {
                     f
                 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -209,6 +209,7 @@ pub(crate) struct FormatProcessData<'a> {
     #[cfg(feature = "ansi")]
     pub(crate) ansi: bool,
     pub(crate) with_trimmed_directory: bool,
+    pub(crate) with_strip_prefix: &'a Option<String>,
 }
 
 impl<'a> fmt::Display for FormatProcessData<'a> {
@@ -224,6 +225,11 @@ impl<'a> fmt::Display for FormatProcessData<'a> {
                     path.file_name()
                         .map(OsStr::to_str)
                         .unwrap_or(Some(f))
+                        .unwrap_or(f)
+                } else if let Some(prefix) = &self.with_strip_prefix {
+                    Path::new(f)
+                        .strip_prefix(prefix)
+                        .map(|path| path.to_str().unwrap())
                         .unwrap_or(f)
                 } else {
                     f

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ pub struct Glog<T = UtcTime> {
     with_thread_names: bool,
     with_target: bool,
     with_trimmed_directory: bool,
+    with_strip_prefix: Option<String>,
 }
 
 impl<T> Glog<T> {
@@ -170,6 +171,7 @@ impl<T> Glog<T> {
             with_target: self.with_target,
             with_span_context: self.with_span_context,
             with_trimmed_directory: self.with_trimmed_directory,
+            with_strip_prefix: self.with_strip_prefix,
         }
     }
 
@@ -190,6 +192,13 @@ impl<T> Glog<T> {
     pub fn with_trimmed_directory(self, with_trimmed_directory: bool) -> Glog<T> {
         Glog {
             with_trimmed_directory,
+            ..self
+        }
+    }
+
+    pub fn with_strip_prefix<S: ToString>(self, with_strip_prefix: Option<S>) -> Glog<T> {
+        Glog {
+            with_strip_prefix: with_strip_prefix.map(|s|s.to_string()),
             ..self
         }
     }
@@ -230,6 +239,7 @@ impl Default for Glog<UtcTime> {
             with_target: false,
             with_span_context: true,
             with_trimmed_directory: false,
+            with_strip_prefix: None,
         }
     }
 }
@@ -276,6 +286,7 @@ where
             #[cfg(feature = "ansi")]
             ansi: writer.has_ansi_escapes(),
             with_trimmed_directory: self.with_trimmed_directory,
+            with_strip_prefix: &self.with_strip_prefix,
         };
         write!(writer, "{}] ", data)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ impl<T> Glog<T> {
 
     pub fn with_trimmed_directory(self, with_trimmed_directory: bool) -> Glog<T> {
         Glog {
-            with_trimmed_directory: with_trimmed_directory,
+            with_trimmed_directory,
             ..self
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub struct Glog<T = UtcTime> {
     with_span_context: bool,
     with_thread_names: bool,
     with_target: bool,
+    with_trimmed_directory: bool,
 }
 
 impl<T> Glog<T> {
@@ -168,6 +169,7 @@ impl<T> Glog<T> {
             with_thread_names: self.with_thread_names,
             with_target: self.with_target,
             with_span_context: self.with_span_context,
+            with_trimmed_directory: self.with_trimmed_directory,
         }
     }
 
@@ -181,6 +183,13 @@ impl<T> Glog<T> {
     pub fn with_target(self, with_target: bool) -> Glog<T> {
         Glog {
             with_target,
+            ..self
+        }
+    }
+
+    pub fn with_trimmed_directory(self, with_trimmed_directory: bool) -> Glog<T> {
+        Glog {
+            with_trimmed_directory: with_trimmed_directory,
             ..self
         }
     }
@@ -220,6 +229,7 @@ impl Default for Glog<UtcTime> {
             with_thread_names: false,
             with_target: false,
             with_span_context: true,
+            with_trimmed_directory: false,
         }
     }
 }
@@ -265,6 +275,7 @@ where
             with_target: self.with_target,
             #[cfg(feature = "ansi")]
             ansi: writer.has_ansi_escapes(),
+            with_trimmed_directory: self.with_trimmed_directory,
         };
         write!(writer, "{}] ", data)?;
 


### PR DESCRIPTION
Hello, we use very long paths.
Our other glog libraries (go and c++) log only the file name and not the full path.
I'd like to have the same for our rust logs, so I made this small addition.