### PR TITLE
use tid instead of pid on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ tracing-log = { version = "0.1", optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = "0.3"
+
 [dev-dependencies]
 thiserror = "1"
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ time = { version = "0.3.9", features = ["formatting"] }
 nu-ansi-term = { version = "0.46", optional = true }
 tracing-log = { version = "0.1", optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 thiserror = "1"
 anyhow = "1"

--- a/src/format.rs
+++ b/src/format.rs
@@ -201,7 +201,7 @@ fn format_datetime(
 }
 
 pub(crate) struct FormatProcessData<'a> {
-    pub(crate) pid: u32,
+    pub(crate) pid: i64,
     pub(crate) thread_name: Option<&'a str>,
     pub(crate) with_thread_names: bool,
     pub(crate) metadata: &'a Metadata<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ where
         let metadata = event.metadata();
 
         let data = FormatProcessData {
-            pid,
+            pid: pid.into(),
             thread_name,
             with_thread_names: self.with_thread_names,
             metadata,
@@ -448,7 +448,14 @@ impl<'a> fmt::Display for ErrorSourceList<'a> {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
 #[inline(always)]
 fn get_pid() -> u32 {
     std::process::id()
+}
+
+#[cfg(target_os = "linux")]
+#[inline(always)]
+fn get_pid() -> i32 {
+    unsafe { libc::gettid() }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl<'a> fmt::Display for ErrorSourceList<'a> {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 #[inline(always)]
 fn get_pid() -> u32 {
     std::process::id()
@@ -458,4 +458,10 @@ fn get_pid() -> u32 {
 #[inline(always)]
 fn get_pid() -> i32 {
     unsafe { libc::gettid() }
+}
+
+#[cfg(target_os = "windows")]
+#[inline(always)]
+fn get_pid() -> u32 {
+     unsafe { winapi::um::processthreadsapi::GetCurrentThreadId() }
 }


### PR DESCRIPTION
Hello, another point of discussion here: we would like to log the thread-id instead of the process-id under linux, similar to what the google glog c++ library does. Not sure if adding this linux specific dependency is ok. I cannot test it under windows right now, and if calling `libc::gettid()` would work under windows (glog c++ uses some windows api to get the thread id).

An example is in this commit: 38158a61b2df243e44f2a057c80b669cc318c226
