### PR TITLE
Add compact output

### DIFF
--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -3,9 +3,20 @@ use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
 use tracing_glog::{Glog, GlogFields, UtcTime};
 
+#[instrument(skip_all)]
+async fn no_fields() {
+    info!("Printing from no_fields");
+    sub_no_fields().await;
+}
+
+#[instrument(skip_all)]
+async fn sub_no_fields() {
+    info!("Printing from sub_no_fields");
+}
+
 #[instrument]
-async fn parent_task(subtasks: usize) -> Result<(), Error> {
-    info!("spawning subtasks...");
+async fn parent_task(subtasks: usize, reason: &str) -> Result<(), Error> {
+    info!("spawning subtasks in {reason}...");
     let mut set = JoinSet::new();
 
     for number in 1..=subtasks {
@@ -36,10 +47,12 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(UtcTime::default()),
+                .with_timer(UtcTime::default())
+                .with_span_names(false)
         )
-        .fmt_fields(GlogFields::default())
+        .fmt_fields(GlogFields::default().compact())
         .init();
-    parent_task(10).await?;
+    parent_task(10, "testing").await?;
+    no_fields().await;
     Ok(())
 }

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Error> {
                 .with_target(false)
                 .with_thread_names(false)
                 .with_timer(UtcTime::default())
-                .with_span_names(false)
+                .with_span_names(false),
         )
         .fmt_fields(GlogFields::default().compact())
         .init();

--- a/examples/tokio_compact.rs
+++ b/examples/tokio_compact.rs
@@ -3,9 +3,20 @@ use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
 use tracing_glog::{Glog, GlogFields, UtcTime};
 
+#[instrument(skip_all)]
+async fn no_fields() {
+    info!("Printing from no_fields");
+    sub_no_fields().await;
+}
+
+#[instrument(skip_all)]
+async fn sub_no_fields() {
+    info!("Printing from sub_no_fields");
+}
+
 #[instrument]
-async fn parent_task(subtasks: usize) -> Result<(), Error> {
-    info!("spawning subtasks...");
+async fn parent_task(subtasks: usize, reason: &str) -> Result<(), Error> {
+    info!("spawning subtasks in {reason}...");
     let mut set = JoinSet::new();
 
     for number in 1..=subtasks {
@@ -36,10 +47,12 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(UtcTime::default()),
+                .with_timer(UtcTime::default())
+                .with_span_names(false),
         )
-        .fmt_fields(GlogFields::default())
+        .fmt_fields(GlogFields::default().compact())
         .init();
-    parent_task(10).await?;
+    parent_task(10, "testing").await?;
+    no_fields().await;
     Ok(())
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -265,6 +265,7 @@ pub(crate) struct FormatSpanFields<'a> {
     fields: Option<&'a str>,
     #[cfg(feature = "ansi")]
     pub ansi: bool,
+    print_span_names: bool,
 }
 
 impl<'a> FormatSpanFields<'a> {
@@ -272,6 +273,7 @@ impl<'a> FormatSpanFields<'a> {
         span_name: &'static str,
         fields: Option<&'a str>,
         ansi: bool,
+        print_span_names: bool,
     ) -> Self {
         #[cfg(not(feature = "ansi"))]
         let _ = ansi;
@@ -280,6 +282,7 @@ impl<'a> FormatSpanFields<'a> {
             fields,
             #[cfg(feature = "ansi")]
             ansi,
+            print_span_names,
         }
     }
 }
@@ -289,17 +292,31 @@ impl<'a> fmt::Display for FormatSpanFields<'a> {
         #[cfg(feature = "ansi")]
         if self.ansi {
             let bold = Style::new().bold();
-            write!(f, "{}", bold.paint(self.span_name))?;
+
+            if self.print_span_names {
+                write!(f, "{}", bold.paint(self.span_name))?;
+            }
 
             let italic = Style::new().italic();
             if let Some(fields) = self.fields {
-                write!(f, "{{{}}}", italic.paint(fields))?;
+                if self.print_span_names {
+                    write!(f, "{{{}}}", italic.paint(fields))?;
+                } else {
+                    write!(f, "{}", italic.paint(fields))?;
+                }
             };
             return Ok(());
         }
-        write!(f, "{}", self.span_name)?;
+
+        if self.print_span_names {
+            write!(f, "{}", self.span_name)?;
+        }
         if let Some(fields) = self.fields {
-            write!(f, "{{{}}}", fields)?;
+            if self.print_span_names {
+                write!(f, "{{{}}}", fields)?;
+            } else {
+                write!(f, "{}", fields)?;
+            }
         };
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,18 +190,18 @@ impl<T> Glog<T> {
     /// Sets whether or not the span name is included. Defaults to true.
     ///
     /// If span names are not included, then the fields from all spans are
-    /// printed as a single list of fields.  This compacts the output and reduces
-    /// the complexity of the output's structure.
+    /// printed as a single list of fields. This results is a more compact output.
     ///
-    /// # Example when `true`
-    /// ```no_compile
+    /// # Example Output
+    /// With `with_span_names` set to true:
+    /// <pre>
     /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [parent_task{subtasks: 10, reason: "testing"}, subtask{number: 10}] polling subtask, number: 10
-    /// ```
+    /// </pre>
     ///
-    /// # Example when `false`
-    /// ```no_compile
+    /// With `with_span_names` set to false:
+    /// <pre>
     /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [subtasks: 10, reason: "testing", number: 10] polling subtask, number: 10
-    /// ```
+    /// <pre>
     pub fn with_span_names(self, with_span_names: bool) -> Glog<T> {
         Glog {
             with_span_names,
@@ -385,15 +385,18 @@ impl GlogFields {
         self
     }
 
-    /// Sets whether or not whitespace is added to printed fields
+    /// Sets whether or not whitespace is added to printed fields.
     ///
-    /// This is helpful for reducing line width.
+    /// This defaults to `false`.
     pub fn use_whitespace_in_field(mut self, value: bool) -> Self {
         self.config.use_whitespace_in_field = value;
         self
     }
 
-    /// Uses formatting options which favor compactness.
+    /// Sets the formatter to use compact options.
+    ///
+    /// Setting `.compat()` will set [`GlogFields::use_whitespace_in_field`]
+    /// and [`GlogFields::should_quote_strings`] to false.
     pub fn compact(self) -> Self {
         self.should_quote_strings(false)
             .use_whitespace_in_field(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl<T> Glog<T> {
     /// With `with_span_names` set to false:
     /// <pre>
     /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [subtasks: 10, reason: "testing", number: 10] polling subtask, number: 10
-    /// <pre>
+    /// </pre>
     pub fn with_span_names(self, with_span_names: bool) -> Glog<T> {
         Glog {
             with_span_names,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,8 +395,7 @@ impl GlogFields {
 
     /// Uses formatting options which favor compactness.
     pub fn compact(self) -> Self {
-        self
-            .should_quote_strings(false)
+        self.should_quote_strings(false)
             .use_whitespace_in_field(false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,12 +194,12 @@ impl<T> Glog<T> {
     /// the complexity of the output's structure.
     ///
     /// # Example when `true`
-    /// ```
+    /// ```no_compile
     /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [parent_task{subtasks: 10, reason: "testing"}, subtask{number: 10}] polling subtask, number: 10
     /// ```
     ///
     /// # Example when `false`
-    /// ```
+    /// ```no_compile
     /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [subtasks: 10, reason: "testing", number: 10] polling subtask, number: 10
     /// ```
     pub fn with_span_names(self, with_span_names: bool) -> Glog<T> {
@@ -477,12 +477,10 @@ impl<'a> Visit for GlogVisitor<'a> {
 
         if field.name() == "message" {
             self.record_debug(field, &format_args!("{}", value))
+        } else if self.config.should_quote_strings {
+            self.record_debug(field, &value)
         } else {
-            if self.config.should_quote_strings {
-                self.record_debug(field, &value)
-            } else {
-                self.record_debug(field, &format_args!("{}", value))
-            }
+            self.record_debug(field, &format_args!("{}", value))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub struct Glog<T = UtcTime> {
     with_span_context: bool,
     with_thread_names: bool,
     with_target: bool,
+    with_span_names: bool,
 }
 
 impl<T> Glog<T> {
@@ -168,6 +169,7 @@ impl<T> Glog<T> {
             with_thread_names: self.with_thread_names,
             with_target: self.with_target,
             with_span_context: self.with_span_context,
+            with_span_names: self.with_span_names,
         }
     }
 
@@ -181,6 +183,28 @@ impl<T> Glog<T> {
     pub fn with_target(self, with_target: bool) -> Glog<T> {
         Glog {
             with_target,
+            ..self
+        }
+    }
+
+    /// Sets whether or not the span name is included. Defaults to true.
+    ///
+    /// If span names are not included, then the fields from all spans are
+    /// printed as a single list of fields.  This compacts the output and reduces
+    /// the complexity of the output's structure.
+    ///
+    /// # Example when `true`
+    /// ```
+    /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [parent_task{subtasks: 10, reason: "testing"}, subtask{number: 10}] polling subtask, number: 10
+    /// ```
+    ///
+    /// # Example when `false`
+    /// ```
+    /// I0731 16:23:45.674465 990039 examples/tokio.rs:38] [subtasks: 10, reason: "testing", number: 10] polling subtask, number: 10
+    /// ```
+    pub fn with_span_names(self, with_span_names: bool) -> Glog<T> {
+        Glog {
+            with_span_names,
             ..self
         }
     }
@@ -220,6 +244,7 @@ impl Default for Glog<UtcTime> {
             with_thread_names: false,
             with_target: false,
             with_span_context: true,
+            with_span_names: true,
         }
     }
 }
@@ -273,8 +298,7 @@ where
             let leaf = ctx.lookup_current();
 
             if let Some(leaf) = leaf {
-                // write the opening brackets
-                write!(writer, "[")?;
+                let mut wrote_open_bracket = false;
 
                 // Write spans and fields of each span
                 let mut iter = leaf.scope().from_root();
@@ -293,25 +317,37 @@ where
                         None
                     };
 
-                    let fields = FormatSpanFields::format_fields(
-                        span.name(),
-                        fields,
-                        writer.has_ansi_escapes(),
-                    );
-                    write!(writer, "{}", fields)?;
+                    if self.with_span_names || fields.is_some() {
+                        if !wrote_open_bracket {
+                            // Write the opening bracket once we know we need one
+                            write!(writer, "[")?;
+                            wrote_open_bracket = true;
+                        }
+                        let fields = FormatSpanFields::format_fields(
+                            span.name(),
+                            fields,
+                            writer.has_ansi_escapes(),
+                            self.with_span_names,
+                        );
+                        write!(writer, "{}", fields)?;
+                    }
 
                     drop(ext);
                     match iter.next() {
                         // if there's more, add a space.
                         Some(next) => {
-                            write!(writer, ", ")?;
+                            if wrote_open_bracket {
+                                write!(writer, ", ")?;
+                            }
                             span = next;
                         }
                         // if there's nothing there, close.
                         None => break,
                     }
                 }
-                write!(writer, "] ")?;
+                if wrote_open_bracket {
+                    write!(writer, "] ")?;
+                }
             }
         }
         ctx.field_format().format_fields(writer.by_ref(), event)?;
@@ -319,15 +355,58 @@ where
     }
 }
 
+#[derive(Clone)]
+struct FieldConfig {
+    should_quote_strings: bool,
+    use_whitespace_in_field: bool,
+}
+
+impl Default for FieldConfig {
+    fn default() -> Self {
+        Self {
+            should_quote_strings: true,
+            use_whitespace_in_field: true,
+        }
+    }
+}
+
 #[derive(Default)]
-pub struct GlogFields;
+pub struct GlogFields {
+    config: FieldConfig,
+}
+
+impl GlogFields {
+    /// Sets whether or not strings are wrapped in quotes.
+    ///
+    /// This is helpful for reducing line width at the cost of clarity when
+    /// using strings with whitespace as fields on Spans and Events.
+    pub fn should_quote_strings(mut self, value: bool) -> Self {
+        self.config.should_quote_strings = value;
+        self
+    }
+
+    /// Sets whether or not whitespace is added to printed fields
+    ///
+    /// This is helpful for reducing line width.
+    pub fn use_whitespace_in_field(mut self, value: bool) -> Self {
+        self.config.use_whitespace_in_field = value;
+        self
+    }
+
+    /// Uses formatting options which favor compactness.
+    pub fn compact(self) -> Self {
+        self
+            .should_quote_strings(false)
+            .use_whitespace_in_field(false)
+    }
+}
 
 impl<'a> MakeVisitor<Writer<'a>> for GlogFields {
     type Visitor = GlogVisitor<'a>;
 
     #[inline]
     fn make_visitor(&self, target: Writer<'a>) -> Self::Visitor {
-        GlogVisitor::new(target)
+        GlogVisitor::new(target, self.config.clone())
     }
 }
 
@@ -337,15 +416,17 @@ pub struct GlogVisitor<'a> {
     is_empty: bool,
     style: Style,
     result: fmt::Result,
+    config: FieldConfig,
 }
 
 impl<'a> GlogVisitor<'a> {
-    fn new(writer: Writer<'a>) -> Self {
+    fn new(writer: Writer<'a>, config: FieldConfig) -> Self {
         Self {
             writer,
             is_empty: true,
             style: Style::new(),
             result: Ok(()),
+            config,
         }
     }
 
@@ -357,6 +438,27 @@ impl<'a> GlogVisitor<'a> {
             ", "
         };
         self.result = write!(self.writer, "{}{:?}", padding, value);
+    }
+
+    fn write_field(&mut self, name: &str, value: &dyn fmt::Debug) {
+        let bold = self.bold();
+        if self.config.use_whitespace_in_field {
+            self.write_padded(&format_args!(
+                "{}{}{}: {:?}",
+                bold.prefix(),
+                name,
+                bold.infix(self.style),
+                value,
+            ));
+        } else {
+            self.write_padded(&format_args!(
+                "{}{}{}:{:?}",
+                bold.prefix(),
+                name,
+                bold.infix(self.style),
+                value,
+            ));
+        }
     }
 
     fn bold(&self) -> Style {
@@ -377,7 +479,11 @@ impl<'a> Visit for GlogVisitor<'a> {
         if field.name() == "message" {
             self.record_debug(field, &format_args!("{}", value))
         } else {
-            self.record_debug(field, &value)
+            if self.config.should_quote_strings {
+                self.record_debug(field, &value)
+            } else {
+                self.record_debug(field, &format_args!("{}", value))
+            }
         }
     }
 
@@ -397,25 +503,12 @@ impl<'a> Visit for GlogVisitor<'a> {
             return;
         }
 
-        let bold = self.bold();
         match field.name() {
             "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
             // Skip fields that are actually log metadata that have already been handled
             name if name.starts_with("log.") => self.result = Ok(()),
-            name if name.starts_with("r#") => self.write_padded(&format_args!(
-                "{}{}{}: {:?}",
-                bold.prefix(),
-                &name[2..],
-                bold.infix(self.style),
-                value
-            )),
-            name => self.write_padded(&format_args!(
-                "{}{}{}: {:?}",
-                bold.prefix(),
-                name,
-                bold.infix(self.style),
-                value
-            )),
+            name if name.starts_with("r#") => self.write_field(&name[2..], value),
+            name => self.write_field(name, value),
         };
     }
 }


### PR DESCRIPTION
Hey!  I've been heavily using tracing recently with both tracing glog and other tracing integrations.

I've been finding the combination somewhat unwieldy because that sweet sweet span context that makes tracing so helpful is making tracing-glog's output unreadable, even on my 4k 32" monitor, it's just too long and there are wayyy too many special characters, especially if I wind up debug printing a rust struct in my message (not even in my context).

I'm pretty sure I'm not alone, because of tracing adoption issues seen on other teams (`with_span_context(false)`).  People are finding the output so verbose that they're disabling it, forgetting they disabled it, and then getting confused when tracing "doesn't work" when they try to add context later.