### PR TITLE
chore: prepare v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-glog"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 description = "a glog-inspired formatter for tracing-subscriber"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Turns out that v0.2.3 was accidentally breaking because of [this change](https://github.com/davidbarsky/tracing-glog/pull/15/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R374). I found this broke https://github.com/cooperlees/monitord during testing, so I yanked v0.2.3.