### PR TITLE
feature: add support for chrono

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -21,8 +21,8 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -35,8 +35,8 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -51,8 +51,8 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -62,3 +62,18 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  cargo-hack:
+    needs: check
+    name: cargo check (feature combinations)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+        run: cargo hack check --feature-powerset --no-dev-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,6 @@ jobs:
           override: true
       - name: install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-        run: cargo hack check --feature-powerset --no-dev-deps
+      - with:
+          command: cargo
+          args: hack check --feature-powerset --no-dev-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - with:
+      - uses: taiki-e/install-action@cargo-hack
+        with:
           command: cargo
           args: hack check --feature-powerset --no-dev-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ documentation = "https://docs.rs/tracing-glog"
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "time", "local-time"], default-features = false }
+tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "time", "local-time", "chrono"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
+chrono = { version = "0.4.20", optional = true }
 nu-ansi-term = { version = "0.46", optional = true }
 tracing-log = { version = "0.1", optional = true }
 
@@ -27,7 +28,16 @@ tokio = { version = "1.21", features = ["full"] }
 default = ["ansi"]
 ansi = ["nu-ansi-term", "tracing-subscriber/ansi"]
 tracing-log = ["dep:tracing-log"]
+chrono = ["dep:chrono", "tracing-subscriber/chrono"]
+
+[[example]]
+name = "tokio"
+required-features = ["chrono", "ansi"]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+tracing = { git = 'https://github.com/tokio-rs/tracing.git', branch = "davidbarsky/backport-changes" }
+tracing-subscriber = { git = 'https://github.com/tokio-rs/tracing.git', branch = "davidbarsky/backport-changes" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-glog"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "a glog-inspired formatter for tracing-subscriber"
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/tracing-glog"
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3.18", features = ["std", "fmt", "registry", "time", "local-time"], default-features = false }
-time = { version = "0.3.9", features = ["formatting"] }
-chrono = { version = "0.4.20", optional = true }
+tracing-subscriber = { version = "0.3.18", features = ["std", "fmt", "registry", "chrono"], default-features = false }
+chrono = { version = "0.4.20" }
+time = { version = "0.3.9", features = ["formatting"], default-features = false, optional = true }
 nu-ansi-term = { version = "0.46", optional = true }
-tracing-log = { version = "0.2", optional = true }
+tracing-log = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 thiserror = "1"
@@ -28,11 +28,12 @@ tokio = { version = "1.21", features = ["full"] }
 default = ["ansi"]
 ansi = ["nu-ansi-term", "tracing-subscriber/ansi"]
 tracing-log = ["dep:tracing-log"]
-chrono = ["dep:chrono", "tracing-subscriber/chrono"]
+time = ["dep:time", "tracing-subscriber/time"]
+local-time = ["dep:time", "tracing-subscriber/local-time"]
 
 [[example]]
 name = "tokio"
-required-features = ["chrono", "ansi"]
+required-features = ["ansi"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-glog"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "a glog-inspired formatter for tracing-subscriber"
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/tracing-glog"
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3.18", features = ["std", "fmt", "chrono", "registry", "time", "local-time", "chrono"], default-features = false }
+tracing-subscriber = { version = "0.3.18", features = ["std", "fmt", "registry", "time", "local-time"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
 chrono = { version = "0.4.20", optional = true }
 nu-ansi-term = { version = "0.46", optional = true }
-tracing-log = { version = "0.1", optional = true }
+tracing-log = { version = "0.2", optional = true }
 
 [dev-dependencies]
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
-tracing = { git = 'https://github.com/tokio-rs/tracing.git', branch = "davidbarsky/backport-changes" }
-tracing-subscriber = { git = 'https://github.com/tokio-rs/tracing.git', branch = "davidbarsky/backport-changes" }
+tracing = { git = 'https://github.com/tokio-rs/tracing.git', branch = "v0.1.x" }
+tracing-subscriber = { git = 'https://github.com/tokio-rs/tracing.git', branch = "v0.1.x" }
+tracing-log = { git = 'https://github.com/tokio-rs/tracing.git', branch = "v0.1.x" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tracing-glog"
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3.3", features = ["std", "fmt", "registry", "time", "local-time", "chrono"], default-features = false }
+tracing-subscriber = { version = "0.3.18", features = ["std", "fmt", "chrono", "registry", "time", "local-time", "chrono"], default-features = false }
 time = { version = "0.3.9", features = ["formatting"] }
 chrono = { version = "0.4.20", optional = true }
 nu-ansi-term = { version = "0.46", optional = true }
@@ -37,8 +37,3 @@ required-features = ["chrono", "ansi"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
-[patch.crates-io]
-tracing = { git = 'https://github.com/tokio-rs/tracing.git', branch = "v0.1.x" }
-tracing-subscriber = { git = 'https://github.com/tokio-rs/tracing.git', branch = "v0.1.x" }
-tracing-log = { git = 'https://github.com/tokio-rs/tracing.git', branch = "v0.1.x" }

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
-use tracing_glog::{ChronoLocalTime, Glog, GlogFields};
+use tracing_glog::{Glog, GlogFields, LocalTime};
 
 #[instrument]
 async fn parent_task(subtasks: usize) -> Result<(), Error> {
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(ChronoLocalTime::default()),
+                .with_timer(LocalTime::default()),
         )
         .fmt_fields(GlogFields::default())
         .init();

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
-use tracing_glog::{Glog, GlogFields, UtcTime};
+use tracing_glog::{ChronoLocalTime, Glog, GlogFields};
 
 #[instrument]
 async fn parent_task(subtasks: usize) -> Result<(), Error> {
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(UtcTime::default()),
+                .with_timer(ChronoLocalTime::default()),
         )
         .fmt_fields(GlogFields::default())
         .init();

--- a/examples/tokio_compact.rs
+++ b/examples/tokio_compact.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
-use tracing_glog::{ChronoLocalTime, Glog, GlogFields};
+use tracing_glog::{Glog, GlogFields, LocalTime};
 
 #[instrument(skip_all)]
 async fn no_fields() {
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(ChronoLocalTime::default())
+                .with_timer(LocalTime::default())
                 .with_span_names(false),
         )
         .fmt_fields(GlogFields::default().compact())

--- a/examples/tokio_compact.rs
+++ b/examples/tokio_compact.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, span, Instrument as _, Level};
-use tracing_glog::{Glog, GlogFields, UtcTime};
+use tracing_glog::{ChronoLocalTime, Glog, GlogFields};
 
 #[instrument(skip_all)]
 async fn no_fields() {
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Error> {
             Glog::default()
                 .with_target(false)
                 .with_thread_names(false)
-                .with_timer(UtcTime::default())
+                .with_timer(ChronoLocalTime::default())
                 .with_span_names(false),
         )
         .fmt_fields(GlogFields::default().compact())

--- a/src/format.rs
+++ b/src/format.rs
@@ -5,6 +5,9 @@ use time::{format_description::FormatItem, formatting::Formattable, OffsetDateTi
 use tracing::{Level, Metadata};
 use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
 
+#[cfg(feature = "chrono")]
+use tracing_subscriber::fmt::time::{ChronoLocal, ChronoUtc};
+
 /// A bridge between `fmt::Write` and `io::Write`.
 ///
 /// This is used by the timestamp formatting implementation for the `time`
@@ -134,6 +137,37 @@ impl Default for UtcTime {
     }
 }
 
+#[cfg(feature = "chrono")]
+pub struct ChronoUtcTime {
+    time: ChronoUtc,
+}
+
+#[cfg(feature = "chrono")]
+impl FormatTime for ChronoUtcTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
+        #[cfg(feature = "ansi")]
+        if w.has_ansi_escapes() {
+            let style = Style::new().dimmed();
+            write!(w, "{}", style.prefix())?;
+            self.time.format_time(w)?;
+            write!(w, "{}", style.suffix())?;
+            return Ok(());
+        }
+
+        self.time.format_time(w)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl Default for ChronoUtcTime {
+    fn default() -> Self {
+        let fmt_string = String::from("%m%d %H:%M:%S%.6f");
+        Self {
+            time: ChronoUtc::new(fmt_string),
+        }
+    }
+}
+
 /// Formats the current [local time] using a [formatter] from the [`time` crate].
 ///
 /// To format the current [UTC time] instead, use the [`UtcTime`] type.
@@ -186,6 +220,36 @@ where
         }
 
         format_datetime(writer, now, &self.format)
+    }
+}
+
+#[cfg(feature = "chrono")]
+pub struct ChronoLocalTime {
+    time: ChronoLocal,
+}
+
+#[cfg(feature = "chrono")]
+impl FormatTime for ChronoLocalTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
+        #[cfg(feature = "ansi")]
+        if w.has_ansi_escapes() {
+            let style = Style::new().dimmed();
+            write!(w, "{}", style.prefix())?;
+            self.time.format_time(w)?;
+            write!(w, "{}", style.suffix())?;
+            return Ok(());
+        }
+
+        self.time.format_time(w)
+    }
+}
+
+impl Default for ChronoLocalTime {
+    fn default() -> Self {
+        let fmt_string = String::from("%m%d %H:%M:%S%.6f");
+        Self {
+            time: ChronoLocal::new(fmt_string),
+        }
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -244,6 +244,7 @@ impl FormatTime for ChronoLocalTime {
     }
 }
 
+#[cfg(feature = "chrono")]
 impl Default for ChronoLocalTime {
     fn default() -> Self {
         let fmt_string = String::from("%m%d %H:%M:%S%.6f");

--- a/src/format.rs
+++ b/src/format.rs
@@ -137,7 +137,15 @@ impl Default for UtcTime {
     }
 }
 
+/// Formats the current [UTC time] using [`chrono` crate].
+///
+/// To format the current local time instead, use the [`ChronoLocalTime`]
+/// or the [`LocalTime`] type.
+///
+/// [UTC time]: ChronoUtc
+/// [`chrono` crate]: chrono
 #[cfg(feature = "chrono")]
+#[derive(Clone, Debug)]
 pub struct ChronoUtcTime {
     time: ChronoUtc,
 }
@@ -223,6 +231,13 @@ where
     }
 }
 
+/// Formats the current [`local time`] using [`chrono` crate].
+///
+/// To format the UTC time instead, use the [`ChronoUtcTime`]
+/// or the [`UtcTime`] type.
+///
+/// [`local time`]: ChronoLocal
+/// [`chrono` crate]: chrono
 #[cfg(feature = "chrono")]
 pub struct ChronoLocalTime {
     time: ChronoLocal,

--- a/src/format.rs
+++ b/src/format.rs
@@ -54,17 +54,17 @@ impl fmt::Display for FmtLevel {
 
 /// Formats the current [UTC time] using [`chrono` crate].
 ///
-/// To format the current local time instead, use the [`ChronoLocalTime`]
+/// To format the current local time instead, use the [`LocalTime`]
 /// or the [`LocalTime`] type.
 ///
 /// [UTC time]: ChronoUtc
 /// [`chrono` crate]: chrono
 #[derive(Clone, Debug)]
-pub struct ChronoUtcTime {
+pub struct UtcTime {
     time: ChronoUtc,
 }
 
-impl FormatTime for ChronoUtcTime {
+impl FormatTime for UtcTime {
     fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
         #[cfg(feature = "ansi")]
         if w.has_ansi_escapes() {
@@ -79,7 +79,7 @@ impl FormatTime for ChronoUtcTime {
     }
 }
 
-impl Default for ChronoUtcTime {
+impl Default for UtcTime {
     fn default() -> Self {
         let fmt_string = String::from("%m%d %H:%M:%S%.6f");
         Self {
@@ -90,16 +90,16 @@ impl Default for ChronoUtcTime {
 
 /// Formats the current [`local time`] using [`chrono` crate].
 ///
-/// To format the UTC time instead, use the [`ChronoUtcTime`]
-/// or the [`UtcTime`] type.
+/// To format the UTC time instead, use the [`UtcTime`]
+/// or the [`crate::time_crate::UtcTime`] type.
 ///
-/// [`local time`]: ChronoLocal
+/// [`local time`]: tracing_subscriber::fmt::time::ChronoLocal
 /// [`chrono` crate]: chrono
-pub struct ChronoLocalTime {
+pub struct LocalTime {
     time: ChronoLocal,
 }
 
-impl FormatTime for ChronoLocalTime {
+impl FormatTime for LocalTime {
     fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
         #[cfg(feature = "ansi")]
         if w.has_ansi_escapes() {
@@ -114,7 +114,7 @@ impl FormatTime for ChronoLocalTime {
     }
 }
 
-impl Default for ChronoLocalTime {
+impl Default for LocalTime {
     fn default() -> Self {
         let fmt_string = String::from("%m%d %H:%M:%S%.6f");
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,14 @@
 #[deny(rustdoc::broken_intra_doc_links)]
 mod format;
 
+#[cfg(feature = "time")]
+pub mod time_crate;
+
 #[cfg(feature = "ansi")]
 mod nu_ansi_term {
     pub use ::nu_ansi_term::*;
 }
+
 #[cfg(not(feature = "ansi"))]
 mod nu_ansi_term {
     // Minimal API shim for nu_ansi_term to avoid a pile of #[cfg(feature = "ansi")] directives.
@@ -124,9 +128,7 @@ mod nu_ansi_term {
 
 use crate::nu_ansi_term::Style;
 use format::FmtLevel;
-#[cfg(feature = "chrono")]
 pub use format::{ChronoLocalTime, ChronoUtcTime};
-pub use format::{LocalTime, UtcTime};
 use std::fmt;
 use tracing::{
     field::{Field, Visit},
@@ -147,7 +149,7 @@ use crate::format::{FormatProcessData, FormatSpanFields};
 /// A [glog]-inspired span and event formatter.
 ///
 /// [glog]: https://github.com/google/glog
-pub struct Glog<T = UtcTime> {
+pub struct Glog<T = ChronoUtcTime> {
     timer: T,
     with_span_context: bool,
     with_thread_names: bool,
@@ -239,10 +241,10 @@ impl<T> Glog<T> {
     }
 }
 
-impl Default for Glog<UtcTime> {
+impl Default for Glog<ChronoUtcTime> {
     fn default() -> Self {
         Glog {
-            timer: UtcTime::default(),
+            timer: ChronoUtcTime::default(),
             with_thread_names: false,
             with_target: false,
             with_span_context: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,8 @@ mod nu_ansi_term {
 
 use crate::nu_ansi_term::Style;
 use format::FmtLevel;
+#[cfg(feature = "chrono")]
+pub use format::{ChronoLocalTime, ChronoUtcTime};
 pub use format::{LocalTime, UtcTime};
 use std::fmt;
 use tracing::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ mod nu_ansi_term {
 
 use crate::nu_ansi_term::Style;
 use format::FmtLevel;
-pub use format::{ChronoLocalTime, ChronoUtcTime};
+pub use format::{LocalTime, UtcTime};
 use std::fmt;
 use tracing::{
     field::{Field, Visit},
@@ -149,7 +149,7 @@ use crate::format::{FormatProcessData, FormatSpanFields};
 /// A [glog]-inspired span and event formatter.
 ///
 /// [glog]: https://github.com/google/glog
-pub struct Glog<T = ChronoUtcTime> {
+pub struct Glog<T = UtcTime> {
     timer: T,
     with_span_context: bool,
     with_thread_names: bool,
@@ -241,10 +241,10 @@ impl<T> Glog<T> {
     }
 }
 
-impl Default for Glog<ChronoUtcTime> {
+impl Default for Glog<UtcTime> {
     fn default() -> Self {
         Glog {
-            timer: ChronoUtcTime::default(),
+            timer: UtcTime::default(),
             with_thread_names: false,
             with_target: false,
             with_span_context: true,

--- a/src/time_crate.rs
+++ b/src/time_crate.rs
@@ -1,0 +1,158 @@
+#[cfg(feature = "ansi")]
+use crate::nu_ansi_term::Style;
+use std::{fmt, io};
+use time::{format_description::FormatItem, formatting::Formattable, OffsetDateTime};
+use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
+
+/// A bridge between `fmt::Write` and `io::Write`.
+///
+/// This is used by the timestamp formatting implementation for the `time`
+/// crate and by the JSON formatter. In both cases, this is needed because
+/// `tracing-subscriber`'s `FormatEvent`/`FormatTime` traits expect a
+/// `fmt::Write` implementation, while `serde_json::Serializer` and `time`'s
+/// `format_into` methods expect an `io::Write`.
+pub(crate) struct WriteAdaptor<'a> {
+    fmt_write: &'a mut dyn fmt::Write,
+}
+
+#[cfg(feature = "time")]
+fn format_datetime(
+    into: &mut Writer<'_>,
+    now: OffsetDateTime,
+    fmt: &impl Formattable,
+) -> fmt::Result {
+    let mut into = WriteAdaptor::new(into);
+    now.format_into(&mut into, fmt)
+        .map_err(|_| fmt::Error)
+        .map(|_| ())
+}
+
+impl<'a> WriteAdaptor<'a> {
+    pub(crate) fn new(fmt_write: &'a mut dyn fmt::Write) -> Self {
+        Self { fmt_write }
+    }
+}
+
+impl<'a> std::io::Write for WriteAdaptor<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let s = std::str::from_utf8(buf)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        self.fmt_write
+            .write_str(s)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        Ok(s.as_bytes().len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> fmt::Debug for WriteAdaptor<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("WriteAdaptor { .. }")
+    }
+}
+
+/// Formats the current [UTC time] using a [formatter] from the [`time` crate].
+///
+/// To format the current [local time] instead, use the [`LocalTime`] type.
+///
+/// [UTC time]: time::OffsetDateTime::now_utc
+/// [formatter]: time::formatting::Formattable
+/// [`time` crate]: time
+/// [local time]: time::OffsetDateTime::now_local
+#[derive(Clone, Debug)]
+pub struct UtcTime<F = Vec<FormatItem<'static>>> {
+    format: F,
+}
+
+impl<F> FormatTime for UtcTime<F>
+where
+    F: Formattable,
+{
+    fn format_time(&self, writer: &mut Writer<'_>) -> fmt::Result {
+        let now = OffsetDateTime::now_utc();
+
+        #[cfg(feature = "ansi")]
+        if writer.has_ansi_escapes() {
+            let style = Style::new().dimmed();
+            write!(writer, "{}", style.prefix())?;
+            format_datetime(writer, now, &self.format)?;
+            write!(writer, "{}", style.suffix())?;
+            return Ok(());
+        }
+
+        format_datetime(writer, now, &self.format)
+    }
+}
+
+impl Default for UtcTime {
+    fn default() -> Self {
+        let format: Vec<FormatItem> = time::format_description::parse(
+            "[month][day] [hour]:[minute]:[second].[subsecond digits:6]",
+        )
+        .expect("Unable to make time formatter");
+        Self { format }
+    }
+}
+
+/// Formats the current [local time] using a [formatter] from the [`time` crate].
+///
+/// To format the current [UTC time] instead, use the [`UtcTime`] type.
+///
+/// <div class="example-wrap" style="display:inline-block">
+/// <pre class="compile_fail" style="white-space:normal;font:inherit;">
+///     <strong>Warning</strong>: The <a href = "https://docs.rs/time/0.3/time/"><code>time</code>
+///     crate</a> must be compiled with <code>--cfg unsound_local_offset</code> in order to use
+///     local timestamps. When this cfg is not enabled, local timestamps cannot be recorded, and
+///     events will be logged without timestamps.
+///
+///    See the <a href="https://docs.rs/time/0.3.4/time/#feature-flags"><code>time</code>
+///    documentation</a> for more details.
+/// </pre></div>
+///
+/// [local time]: time::OffsetDateTime::now_local
+/// [formatter]: time::formatting::Formattable
+/// [`time` crate]: time
+/// [UTC time]: time::OffsetDateTime::now_utc
+#[derive(Clone, Debug)]
+#[cfg(feature = "local-time")]
+pub struct LocalTime<F = Vec<FormatItem<'static>>> {
+    format: F,
+}
+
+#[cfg(feature = "local-time")]
+impl Default for LocalTime {
+    fn default() -> Self {
+        let format: Vec<FormatItem> = time::format_description::parse(
+            "[month][day] [hour]:[minute]:[second].[subsecond digits:6]",
+        )
+        .expect("Unable to make time formatter");
+        Self { format }
+    }
+}
+
+#[cfg(feature = "local-time")]
+impl<F> FormatTime for LocalTime<F>
+where
+    F: Formattable,
+{
+    fn format_time(&self, writer: &mut Writer<'_>) -> fmt::Result {
+        let now = OffsetDateTime::now_local().map_err(|_| fmt::Error)?;
+
+        #[cfg(feature = "ansi")]
+        if writer.has_ansi_escapes() {
+            let style = Style::new().dimmed();
+            write!(writer, "{}", style.prefix())?;
+            format_datetime(writer, now, &self.format)?;
+            // necessary to provide space between the time and the PID
+            write!(writer, "{}", style.suffix())?;
+            return Ok(());
+        }
+
+        format_datetime(writer, now, &self.format)
+    }
+}


### PR DESCRIPTION
(Note that this PR will require https://github.com/tokio-rs/tracing/pull/2728/ to land first.)

Since `chrono` added support for local time support (without relying on unsound behavior), it's probably useful to add this functionality to `tracing-glog` behind a feature flag. I don't want to cut another breaking change for this crate _yet_, but I expect by `tracing-glog 0.4` to place both `time` and `chrono` under feature flags.

Before landing this, I'd like to write documentation for this functionality.