### PR TITLE
examples: port from structopt to clap/derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tracing-log = { version = "0.2", default-features = false, optional = true }
 [dev-dependencies]
 thiserror = "1"
 anyhow = "1"
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 tracing = { version = "0.1" }
 tokio = { version = "1.21", features = ["full"] }
 

--- a/examples/yak-shave.rs
+++ b/examples/yak-shave.rs
@@ -1,4 +1,4 @@
-use structopt::StructOpt;
+use clap::Parser;
 use thiserror::Error;
 use tracing::{debug, error, info, span, trace, warn, Level};
 use tracing_glog::{Glog, GlogFields};
@@ -13,19 +13,19 @@ use tracing_glog::{Glog, GlogFields};
 /// cargo run --example yak-shave
 /// ```
 
-#[derive(Debug, structopt::StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
     /// Whether to run this example with or without ANSI colors.
-    #[structopt(long)]
+    #[clap(long)]
     with_ansi: bool,
 
     /// Whether tracing-glog should include the span context.
-    #[structopt(long)]
+    #[clap(long)]
     with_span_context: bool,
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     tracing_subscriber::fmt()
         .with_ansi(args.with_ansi)


### PR DESCRIPTION
The `structopt` crate is obsolete, it continues to depend on clap v2, and its functionality was merged into clap itself as of v3. So porting from `structopt::StructOpt` to `clap::Parser` is straightforward (just replacing some names).
